### PR TITLE
Features/apartment navigation

### DIFF
--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -235,6 +235,9 @@ public:
         uint64_t type
     );
 
+    ACTION testactn(name account, uint64_t asset_id, uint64_t template_id, string data);
+
+
     [[eosio::on_notify("atomicassets::transfer")]] void receive_asset_transfer(
         name from,
         name to,
@@ -697,6 +700,20 @@ private:
 
     earnTable_t earntable = earnTable_t(get_self(), get_self().value); 
 
+    //apartment table 
+    TABLE apartments_s{
+
+        name account;
+        string collection;
+        
+        uint64_t primary_key() const { return account.value; }
+
+    };
+
+    typedef multi_index<name("apartments"), apartments_s> apartments_t;
+
+    apartments_t apartments = apartments_t(get_self(), get_self().value); 
+
 
     // AUXILIAR FUNCTIONS
     uint64_t finder(vector<asset> assets, symbol symbol); 
@@ -716,7 +733,8 @@ private:
     symbol tokenConversion(symbol s1);
     uint32_t epochToDay(time_t time);
     float getEarnReturns(float stakedAmount, uint64_t stakingTime, int APY, symbol token);
-
+    void stakeapartment(name account, uint64_t asset_id, uint64_t template_id, string data);
+    void unstakeapartment(name account, uint64_t asset_id);
     // CONSTANTS
 
     // const string COLLECTION_NAME = "clashdomewld";

--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -246,7 +246,7 @@ public:
         uint64_t type
     );
 
-    ACTION testactn(name account, uint64_t asset_id, uint64_t template_id, string data);
+    ACTION apartspop(string table_name);
 
 
     [[eosio::on_notify("atomicassets::transfer")]] void receive_asset_transfer(
@@ -781,7 +781,9 @@ private:
     symbol tokenConversion(symbol s1);
     uint32_t epochToDay(time_t time);
     float getEarnReturns(float stakedAmount, uint64_t stakingTime, int APY, symbol token);
-    
+    void stakeapartment(name account, uint64_t asset_id, uint64_t template_id, string data);
+    void unstakeapartment(name account, uint64_t asset_id);
+
 
     // CONSTANTS
 

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -1198,6 +1198,10 @@ void clashdomewld::erasetable(
         for (auto itr = earntable.begin(); itr != earntable.end();) {
             itr = earntable.erase(itr);
         }
+    }else if (table_name == "apartments") {
+        for (auto itr = apartments.begin(); itr != apartments.end();) {
+            itr = apartments.erase(itr);
+        }
     }
 
 }
@@ -2909,6 +2913,62 @@ float clashdomewld::getEarnReturns(float stakedAmount, uint64_t stakingTime, int
     }else{ //devolver sin intereses
         return stakedAmount;
     } 
+}
+
+//APARTMENTS table 
+void clashdomewld::stakeapartment(name account, uint64_t asset_id, uint64_t template_id, string data){
+
+    auto ptaptsitr = apartments.find(account.value);
+
+    json asset_info;
+    asset_info["tid"] = template_id;
+    if(data != "NULL") asset_info["data"] = data;
+    
+    if (ptaptsitr == apartments.end()) {
+
+        json apartment_data;
+        apartment_data[to_string(asset_id)]= asset_info;
+        string stake_data_str =  apartment_data.dump();
+
+        ptaptsitr = apartments.emplace(CONTRACTN, [&](auto &new_a) {
+            new_a.account = account;
+            new_a.collection = stake_data_str; 
+        });
+
+    }else{
+        
+        json apartment_data = json::parse(ptaptsitr->collection);
+        apartment_data[to_string(asset_id)]= asset_info;
+        string stake_data_str =  apartment_data.dump();
+
+        apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
+                mod_acc.collection = stake_data_str;
+            });
+        }
+}
+
+void clashdomewld::unstakeapartment(name account, uint64_t asset_id){
+
+    auto ptaptsitr = apartments.find(account.value);
+
+    check( ptaptsitr != apartments.end(), "No content on the apartments table to delete !");
+
+    json apartment_data = json::parse(ptaptsitr->collection);
+    apartment_data.erase(apartment_data.find(to_string(asset_id)));
+    string tmp =  apartment_data.dump();
+
+    apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
+                mod_acc.collection = tmp;
+            });
+
+}
+
+void clashdomewld::testactn(name account, uint64_t asset_id, uint64_t template_id, string data){
+
+    //stakeapartment(account , asset_id, template_id, data);
+
+    unstakeapartment(account, asset_id);
+    
 }
 
 symbol clashdomewld::tokenConversion(symbol s1){

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -118,6 +118,7 @@ void clashdomewld::unstake(
         ).send();
 
         tools.erase(tool_itr);
+        unstakeapartment(account,asset_id);//apartments
     } else if (type == SLOT_SCHEMA_NAME) {
 
         auto ac_itr = accounts.find(account.value);
@@ -221,6 +222,7 @@ void clashdomewld::unstake(
         ).send();
 
         wallets.erase(wallet_itr);
+        unstakeapartment(account,asset_id);//apartments
     } else if (type == DECORATION_SCHEMA_NAME) {
 
         auto ac_itr = accounts.find(account.value);
@@ -247,6 +249,7 @@ void clashdomewld::unstake(
         ).send();
 
         decorations.erase(decoration_itr);
+        unstakeapartment(account,asset_id);//apartments
     }
 }
 
@@ -1278,6 +1281,9 @@ void clashdomewld::setdecdata(
     decorations.modify(decoration_itr, CONTRACTN, [&](auto& decoration) {
         decoration.data = data;
     });
+
+    //apartments
+    stakeapartment(account, asset_id,decoration_itr->template_id, data);
 }
 
 void clashdomewld::initgsconf()
@@ -2531,6 +2537,7 @@ void clashdomewld::stakeTool(uint64_t asset_id, name from, name to)
         tool.max_integrity = tool_itr->integrity;
         tool.last_claim = 0;
     });
+    stakeapartment(from, asset_id ,asset_itr->template_id, "NULL");
 }
 
 void clashdomewld::stakeSlot(uint64_t asset_id, name from, name to, string type)
@@ -2600,6 +2607,9 @@ void clashdomewld::stakeWallet(uint64_t asset_id, name from, name to)
         wallet.owner = from;
         wallet.template_id = asset_itr->template_id;
     });
+
+    //apartments 
+    stakeapartment(from, asset_id, asset_itr->template_id, "NULL");
 }
 
 void clashdomewld::stakeDecoration(uint64_t asset_id, name from, name to)
@@ -2635,6 +2645,9 @@ void clashdomewld::stakeDecoration(uint64_t asset_id, name from, name to)
         decoration.owner = from;
         decoration.template_id = asset_itr->template_id;
     });
+    //apartments table
+    stakeapartment(from, asset_id , asset_itr->template_id, "NULL");
+
 }
 
 void clashdomewld::addFriend(name account, name fraccount)
@@ -3250,7 +3263,7 @@ void clashdomewld::stakeapartment(name account, uint64_t asset_id, uint64_t temp
     auto ptaptsitr = apartments.find(account.value);
 
     json asset_info;
-    asset_info["tid"] = template_id;
+    asset_info["id"] = template_id;
     if(data != "NULL") asset_info["data"] = data;
     
     if (ptaptsitr == apartments.end()) {
@@ -3267,37 +3280,67 @@ void clashdomewld::stakeapartment(name account, uint64_t asset_id, uint64_t temp
     }else{
         
         json apartment_data = json::parse(ptaptsitr->collection);
-        apartment_data[to_string(asset_id)]= asset_info;
+        if(apartment_data.find(to_string(asset_id)) == apartment_data.end()){
+            apartment_data[to_string(asset_id)]= asset_info;
+        }else{ //data modify
+            apartment_data[to_string(asset_id)]["data"] = data;
+        }
         string stake_data_str =  apartment_data.dump();
 
-        apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
-                mod_acc.collection = stake_data_str;
-            });
-        }
+            apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
+                    mod_acc.collection = stake_data_str;
+                });
+    }
 }
 
 void clashdomewld::unstakeapartment(name account, uint64_t asset_id){
 
     auto ptaptsitr = apartments.find(account.value);
 
-    check( ptaptsitr != apartments.end(), "No content on the apartments table to delete !");
-
+    if(ptaptsitr != apartments.end()){
     json apartment_data = json::parse(ptaptsitr->collection);
-    apartment_data.erase(apartment_data.find(to_string(asset_id)));
-    string tmp =  apartment_data.dump();
+        if(apartment_data.find(to_string(asset_id)) != apartment_data.end()){
+            json apartment_data = json::parse(ptaptsitr->collection);
+            apartment_data.erase(apartment_data.find(to_string(asset_id)));
+            string tmp =  apartment_data.dump();
 
-    apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
-                mod_acc.collection = tmp;
-            });
-
+            apartments.modify(ptaptsitr, get_self(), [&](auto &mod_acc) {
+                        mod_acc.collection = tmp;
+                    });
+        }
+    }
 }
 
-void clashdomewld::testactn(name account, uint64_t asset_id, uint64_t template_id, string data){
+void clashdomewld::apartspop(string table_name){
 
-    //stakeapartment(account , asset_id, template_id, data);
+    require_auth(get_self());
 
-    unstakeapartment(account, asset_id);
-    
+    if (table_name == "tools") {
+        for (auto itr = tools.begin(); itr != tools.end(); itr++) {
+            name owner = itr->owner;
+            uint64_t asset_id = itr->asset_id;
+            uint32_t template_id = itr->template_id;
+            stakeapartment(owner, asset_id, template_id , "NULL");
+        }
+    }else if (table_name == "wallets") {
+        for (auto itr = wallets.begin(); itr != wallets.end(); itr++) {
+            name owner = itr->owner;
+            uint64_t asset_id = itr->asset_id;
+            uint32_t template_id = itr->template_id;
+            stakeapartment(owner, asset_id, template_id , "NULL");
+        }
+    }else if (table_name == "decorations") {
+        for (auto itr = decorations.begin(); itr != decorations.end(); itr++) {
+            name owner = itr->owner;
+            uint64_t asset_id = itr->asset_id;
+            uint32_t template_id = itr->template_id;
+            string data = itr->data;
+            if(data==""){ 
+                data = "NULL";
+            }
+            stakeapartment(owner, asset_id, template_id , data);
+        }
+    }
 }
 
 symbol clashdomewld::tokenConversion(symbol s1){


### PR DESCRIPTION
Para los apartamentos he creado 3 nuevas funciones  y una tabla 



La tabla apartments que es simplemente una tabla con un nombre de key y un string que es donde se guarda el json de todas las cosas del apartamento:

https://github.com/ClashDome/clashdome-world-smart-contract/blob/6149a33a3e4f502dd731e6b786293f63e874b58e/include/clashdomewld.hpp#L732-L744

La función  stakeapartments , que inserta al json la decoración o maquina que el jugador haga stake y edita el json si se cambia la data de algún item:

https://github.com/ClashDome/clashdome-world-smart-contract/blob/6149a33a3e4f502dd731e6b786293f63e874b58e/src/clashdomewld.cpp#L3261-L3294

la función unstakeapartment, que borra una propiedad del JSON.

https://github.com/ClashDome/clashdome-world-smart-contract/blob/6149a33a3e4f502dd731e6b786293f63e874b58e/src/clashdomewld.cpp#L3296-L3312

y por ultimo la acción apartspop que es para migrar los datos de los items ya stakeados hasta el momento, esta hecha para que se tenga que llamar 3 veces `("tools" , "wallets" y "decorations")` por temas de cpu: https://github.com/ClashDome/clashdome-world-smart-contract/blob/6149a33a3e4f502dd731e6b786293f63e874b58e/src/clashdomewld.cpp#L3314-L3344

Esta ultima acción se tiene que probar si funciona ya que por limitaciones de cpu no se si dará algún problema 