### PR TITLE
Counting daily  LUDIO rewards of tacoswap in the tokenomics

### DIFF
--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -245,6 +245,11 @@ public:
         uint64_t id
     );
 
+    ACTION drconfig(
+        asset dr,
+        uint32_t end_day
+    );
+
     ACTION cpurentstats(name account, asset amount);
 
 
@@ -755,6 +760,20 @@ private:
     typedef multi_index<name("earn"), earn_s> earn_t;
 
     earn_t earn = earn_t(get_self(), get_self().value); 
+
+    TABLE dailyrewards_s{
+        
+        uint64_t id;
+        asset reward_ludio;
+        uint32_t end_day;
+        
+        uint64_t primary_key() const { return id; }
+
+    };
+
+    typedef multi_index<name("dailyrewards"), dailyrewards_s> dailyrewards_t;
+
+    dailyrewards_t dailyrewards = dailyrewards_t(get_self(), get_self().value); 
 
     // AUXILIAR FUNCTIONS
     uint64_t finder(vector<asset> assets, symbol symbol); 

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -2925,7 +2925,8 @@ void clashdomewld::updateDailyStats(asset assetVal,int type){
     auto ptokenstatsitr = tokenstats.find(day);
 
     if (ptokenstatsitr == tokenstats.end()) {
-
+        
+        asset dr = dailyrewards.begin()->end_day >= day ? dailyrewards.begin()->reward_ludio : nullasset;
         tokenstats.erase(tokenstats.begin());                 //We delete the oldest row in the table
 
         ptokenstatsitr = tokenstats.emplace(CONTRACTN, [&](auto &new_d) {
@@ -2934,7 +2935,7 @@ void clashdomewld::updateDailyStats(asset assetVal,int type){
             new_d.consumed_carbz=nullasset;
             new_d.burned_carbz=nullasset;
             nullasset.symbol=CREDITS_SYMBOL;
-            new_d.mined_credits=nullasset;
+            new_d.mined_credits=dr;
             new_d.consumed_credits=nullasset;
             new_d.burned_credits=nullasset;
             nullasset.symbol=JIGOWATTS_SYMBOL;
@@ -3019,6 +3020,27 @@ void clashdomewld::updateDailyStats(asset assetVal,int type){
         }
     }
 } 
+
+void clashdomewld::drconfig(asset dr,uint32_t end_day){
+
+    require_auth(get_self());
+    
+    if(dailyrewards.begin() == dailyrewards.end()){
+
+        dailyrewards.emplace(CONTRACTN, [&](auto &new_a) {
+            new_a.id = 0;
+            new_a.reward_ludio = dr;
+            new_a.end_day = end_day;
+
+        });
+    }
+
+    dailyrewards.modify(dailyrewards.begin(), get_self(), [&](auto &mod_acc) {
+            mod_acc.id = 0;
+            mod_acc.reward_ludio = dr;
+            mod_acc.end_day = end_day;
+        });
+}
 
 void clashdomewld::cpurentstats(name account, asset amount){
 


### PR DESCRIPTION
He añadido una tabla nueva donde tiene que estar la recompensa diaria + el día en el que terminan las recompensas .
Se añade a las estadísticas cada día. 

Para llenar la tabla hay una nueva acción que se llama drconfig, se tiene que llamar con la recompensa en creditos "500.0000 CREDITS" y el día que termina "20221017"
