### PR TITLE
Features/apartment voting

### DIFF
--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -245,6 +245,10 @@ public:
         uint64_t id
     );
 
+    ACTION disablenot(
+        name account
+    );
+
     ACTION cpurentstats(name account, asset amount);
 
     ACTION initvotapt(name account);
@@ -850,6 +854,7 @@ private:
     const string APARTMENT_VOTING_APARTMENTS= "apts";
     const string APARTMENT_SCORE= "as";
     const string MISSION_COMPLETE = "mc";
+    const string MISSION_NOFITICATION_STATE = "ns";
 
     //apartment constants
     const string APARTMENT_VOTES = "v";

--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -247,6 +247,7 @@ public:
 
     ACTION cpurentstats(name account, asset amount);
 
+    ACTION initvotapt(name account);
 
     [[eosio::on_notify("atomicassets::transfer")]] void receive_asset_transfer(
         name from,
@@ -751,10 +752,24 @@ private:
         uint64_t primary_key() const { return account.value; }
 
     };
-
+    
     typedef multi_index<name("earn"), earn_s> earn_t;
 
     earn_t earn = earn_t(get_self(), get_self().value); 
+
+    TABLE missions_s{
+            
+            name account;
+            string missions;
+            
+            uint64_t primary_key() const { return account.value; }
+
+        };
+
+
+    typedef multi_index<name("missions"), missions_s> missions_t;
+
+    missions_t missions = missions_t(get_self(), get_self().value); 
 
     // AUXILIAR FUNCTIONS
     uint64_t finder(vector<asset> assets, symbol symbol); 
@@ -806,6 +821,14 @@ private:
     const string EARN_ASSET = "a";
     const string EARN_QUANTITY = "q";
     const string EARN_TIMESTAMP = "t";
+
+    //missions constants
+    const string APARTMENT_VOTING_MISSION = "avm";
+    const string APARTMENT_VOTING_START_TIME = "msst";
+    const string APARTMENT_VOTING_APARTMENTS_NAME= "mn";
+    const string APARTMENT_VOTING_APARTMENTS_SCORE= "ms";
+    const string APARTMENT_VOTING_APARTMENTS= "apts";
+    const string APARTMENT_SCORE= "as";
 
 
     // mainnet

--- a/include/clashdomewld.hpp
+++ b/include/clashdomewld.hpp
@@ -249,6 +249,10 @@ public:
 
     ACTION initvotapt(name account);
 
+    ACTION voteapts(name account, string scores);
+
+    ACTION voteconfig(asset voter_reward, asset voted_reward);
+
     [[eosio::on_notify("atomicassets::transfer")]] void receive_asset_transfer(
         name from,
         name to,
@@ -769,7 +773,23 @@ private:
 
     typedef multi_index<name("missions"), missions_s> missions_t;
 
-    missions_t missions = missions_t(get_self(), get_self().value); 
+    missions_t missions = missions_t(get_self(), get_self().value);
+
+    TABLE votingconfig_s{
+            
+            uint64_t id;
+            asset voting_reward;
+            asset voted_reward;
+            
+            uint64_t primary_key() const { return id; }
+
+        };
+
+
+    typedef multi_index<name("votingconfig"), votingconfig_s> votingconfig_t;
+
+    votingconfig_t votingconfig = votingconfig_t(get_self(), get_self().value);
+ 
 
     // AUXILIAR FUNCTIONS
     uint64_t finder(vector<asset> assets, symbol symbol); 
@@ -829,6 +849,11 @@ private:
     const string APARTMENT_VOTING_APARTMENTS_SCORE= "ms";
     const string APARTMENT_VOTING_APARTMENTS= "apts";
     const string APARTMENT_SCORE= "as";
+    const string MISSION_COMPLETE = "mc";
+
+    //apartment constants
+    const string APARTMENT_VOTES = "v";
+    const string APARTMENT__NO_VOTES = "n";
 
 
     // mainnet

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -3027,11 +3027,11 @@ void clashdomewld::updateDailyStats(asset assetVal,int type){
 void clashdomewld::cpurentstats(name account, asset amount){
 
     name c1 = name("clashdomestk");
-    name c2 = name("clashomesk4");
+    name c2 = name("clashdomesk4");
     name c3 = name("clashdomesk5");
 
     if(account == c1){
-        require_auth(name(c1));
+        require_auth(c1);
     }else if(account == c2){
         require_auth(c2);
     }else if(account == c3){
@@ -3369,27 +3369,28 @@ void clashdomewld::initvotapt(name account){
             new_a.missions = "";
         });   
     }else{
-        json missions_data = json::parse(missionsitr->missions);
+        missions_data = json::parse(missionsitr->missions);
+        
     }
     if(missions_data.find(APARTMENT_VOTING_MISSION) != missions_data.end()){
+    
     uint64_t st = missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME];
-    check(st + (3600*24*7) > timestamp, "Mission isn't ready yet, wait "+ to_string(st + (3600*24*7) - timestamp) +"s");
+    check(st + (3600*24*7) < timestamp, "Mission isn't ready yet, wait "+ to_string(st + (3600*24*7) - timestamp) +"s");
     }
-    auto size = std::distance(apartments.cbegin(),apartments.cend());
+    auto size = std::distance(citiz.cbegin(),citiz.cend());
     auto rnd = (timestamp % size) ;
-    auto start_mission_itr= apartments.begin();
-    for (int i = 5; i < rnd; i++){ 
-        if(start_mission_itr == apartments.end()){break;}
-        //start_mission_itr++;
+    auto start_mission_itr= citiz.begin();
+    for (int i = 5; i < rnd; i++){
+        if(start_mission_itr == citiz.end()){break;}
+        if(size >5)start_mission_itr++;
     }
 
     json apts;
     for (int i = 0; i < 5; i++){
 
-        if(start_mission_itr == apartments.end()){break;}
+        if(start_mission_itr == citiz.end()){continue;}
         apts[start_mission_itr->account.to_string()][APARTMENT_SCORE]= 0;
         start_mission_itr++;
-
     }
     missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_APARTMENTS] = apts; 
     missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME] = timestamp; 
@@ -3399,4 +3400,165 @@ void clashdomewld::initvotapt(name account){
     missions.modify(missionsitr, get_self(), [&](auto &mod_acc) {
             mod_acc.missions = missions_data_str;
         });
+}
+
+void clashdomewld::voteapts(name account, string scores){
+
+    require_auth(account);
+    auto missionsitr = missions.find(account.value);
+    check(missionsitr != missions.end(), "You don't have any missions pending");
+    json missions_data = json::parse(missionsitr->missions);
+    check(missions_data.find(APARTMENT_VOTING_MISSION) != missions_data.end(), "You don't have an open voting mission");
+    json voting_mission = missions_data[APARTMENT_VOTING_MISSION];
+    json apartments_to_vote = voting_mission[APARTMENT_VOTING_APARTMENTS];
+    check(voting_mission.find(MISSION_COMPLETE) == voting_mission.end(), "You've already submitted this weeks votes");
+    json votes = json::parse(scores);
+    check(apartments_to_vote.size() == votes.size(), "Please vote every asigned player!");
+
+    for (const auto& item : votes.items())
+    {   
+        name visited = name(item.key());
+        int scored = item.value();
+        check(apartments_to_vote.find(item.key()) != apartments_to_vote.end(), "Vote submitted doesn't match asigned users!");
+        check(scored > 0 && scored <6, "Only scores 1-5 allowed!");
+        check(apartments_to_vote[item.key()][APARTMENT_SCORE] == 0 , "You cannot vote the same person more than once!");
+        apartments_to_vote[item.key()][APARTMENT_SCORE] = scored;
+        //cuenta votada 
+        auto voteditr = apartments.find(visited.value);
+        if(voteditr == apartments.end()) {
+
+            voteditr = apartments.emplace(CONTRACTN, [&](auto &new_a) {
+            new_a.account = visited;
+            new_a.collection = "{}"; 
+        });
+
+        }
+        json aptscore = json::parse(voteditr->collection);
+        json temp;
+        int score = 0;
+        int votes = 0;
+        if(aptscore.find(APARTMENT_SCORE) != aptscore.end()){
+            score = aptscore[APARTMENT_SCORE][APARTMENT_VOTES];
+            votes = aptscore[APARTMENT_SCORE][APARTMENT__NO_VOTES];
+        }
+        score = score + scored;
+        votes++;
+        aptscore[APARTMENT_SCORE][APARTMENT_VOTES] = score;
+        aptscore[APARTMENT_SCORE][APARTMENT__NO_VOTES]= votes;
+        string aptscore_str = aptscore.dump();
+       
+        apartments.modify(voteditr, get_self(), [&](auto &mod_acc) {
+            mod_acc.collection = aptscore_str;
+        });
+
+        auto ac_itr = accounts.find(visited.value);
+
+        if (ac_itr != accounts.end()) {
+
+            asset credits ;
+            
+            credits.amount = votingconfig.begin()->voted_reward.amount * (scored-1) ;// *  mult ; //recompensa para los votados min 5 ludio max 20 ludio;
+            credits.symbol = CREDITS_SYMBOL; 
+            json unclaimed_actions_json;
+            unclaimed_actions_json["voting"] = credits.amount;
+            vector<string> new_actions = ac_itr->unclaimed_actions;
+
+            new_actions.push_back(unclaimed_actions_json.dump());
+
+            auto config_itr = config.begin();
+
+            auto wallet_idx = wallets.get_index<name("byowner")>();
+            auto wallet_itr = wallet_idx.find(visited.value);
+
+            uint64_t max_amount = config_itr->max_unclaimed_credits * 10000;
+
+            if (wallet_itr == wallet_idx.end()) {
+                if (ac_itr->unclaimed_credits.amount + credits.amount > max_amount) {
+                    accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                        account_itr.unclaimed_credits.amount = max_amount;
+                        account_itr.unclaimed_actions = new_actions;
+                    });
+                } else {
+                    accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                        account_itr.unclaimed_credits.amount += credits.amount;
+                        account_itr.unclaimed_actions = new_actions;
+                    });
+                }
+            }else {
+                accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                    account_itr.unclaimed_credits.amount += credits.amount;
+                    account_itr.unclaimed_actions = new_actions;
+                });
+            }
+        }
+    }
+
+    //cuenta que vota
+    voting_mission[MISSION_COMPLETE] = "true";
+    voting_mission[APARTMENT_VOTING_APARTMENTS] = apartments_to_vote;
+    missions_data[APARTMENT_VOTING_MISSION] = voting_mission;
+    string missions_data_str = missions_data.dump();
+
+    missions.modify(missionsitr, get_self(), [&](auto &mod_acc) {
+            mod_acc.missions = missions_data_str;
+        });
+    auto ac_itr = accounts.find(account.value);
+
+        if (ac_itr != accounts.end()) {
+
+            asset credits ;
+            credits.amount = votingconfig.begin()->voting_reward.amount;
+            credits.symbol = CREDITS_SYMBOL;
+            json unclaimed_actions_json;
+            unclaimed_actions_json["voting"] = credits.amount;
+            vector<string> new_actions = ac_itr->unclaimed_actions;
+
+            new_actions.push_back(unclaimed_actions_json.dump());
+
+            auto config_itr = config.begin();
+
+            auto wallet_idx = wallets.get_index<name("byowner")>();
+            auto wallet_itr = wallet_idx.find(account.value);
+
+            uint64_t max_amount = config_itr->max_unclaimed_credits * 10000;
+
+            if (wallet_itr == wallet_idx.end()) {
+                if (ac_itr->unclaimed_credits.amount + credits.amount > max_amount) {
+                    accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                        account_itr.unclaimed_credits.amount = max_amount;
+                        account_itr.unclaimed_actions = new_actions;
+                    });
+                } else {
+                    accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                        account_itr.unclaimed_credits.amount += credits.amount;
+                        account_itr.unclaimed_actions = new_actions;
+                    });
+                }
+            }else {
+                accounts.modify(ac_itr, CONTRACTN, [&](auto& account_itr) {
+                    account_itr.unclaimed_credits.amount += credits.amount;
+                    account_itr.unclaimed_actions = new_actions;
+                });
+            }
+        }
+}
+void clashdomewld::voteconfig(asset voter_reward, asset voted_reward){
+
+    require_auth(get_self());
+
+    if(votingconfig.begin() == votingconfig.end()){
+
+        votingconfig.emplace(CONTRACTN, [&](auto &new_a) {
+            new_a.id = 0;
+            new_a.voting_reward = voter_reward;
+            new_a.voted_reward = voted_reward;
+        });   
+
+    }else{
+        auto votingconfigtptr = votingconfig.begin();
+        votingconfig.modify(votingconfig.begin(), CONTRACTN, [&](auto& account_itr) {
+                    account_itr.voting_reward = voter_reward;
+                    account_itr.voted_reward = voted_reward;
+                });
+    }
 }

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -3360,10 +3360,10 @@ uint32_t clashdomewld::epochToDay(time_t time){
 void clashdomewld::initvotapt(name account){
 
     require_auth(account);
-    auto ac_itr = accounts.find(from.value);
+    auto ac_itr = accounts.find(account.value);
     check(ac_itr != accounts.end(), "Stake a citizen first!!");
 
-    auto citizen_itr = citiz.find(from.value);
+    auto citizen_itr = citiz.find(account.value);
     check(citizen_itr != citiz.end(), "Stake a citizen first!"); 
     
     uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
@@ -3418,7 +3418,7 @@ void clashdomewld::voteapts(name account, string scores){
     check(missions_data.find(APARTMENT_VOTING_MISSION) != missions_data.end(), "You don't have an open voting mission");
     json voting_mission = missions_data[APARTMENT_VOTING_MISSION];
     json apartments_to_vote = voting_mission[APARTMENT_VOTING_APARTMENTS];
-    check(voting_mission.find(MISSION_COMPLETE) == voting_mission.end(), "You've already submitted this weeks votes");
+    check(voting_mission[MISSION_COMPLETE] != "true", "You've already submitted this weeks votes");
     json votes = json::parse(scores);
     check(apartments_to_vote.size() == votes.size(), "Please vote every asigned player!");
 

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -3360,6 +3360,12 @@ uint32_t clashdomewld::epochToDay(time_t time){
 void clashdomewld::initvotapt(name account){
 
     require_auth(account);
+    auto ac_itr = accounts.find(from.value);
+    check(ac_itr != accounts.end(), "Stake a citizen first!!");
+
+    auto citizen_itr = citiz.find(from.value);
+    check(citizen_itr != citiz.end(), "Stake a citizen first!"); 
+    
     uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
     auto missionsitr = missions.find(account.value);
     json missions_data;
@@ -3374,27 +3380,28 @@ void clashdomewld::initvotapt(name account){
     }
     if(missions_data.find(APARTMENT_VOTING_MISSION) != missions_data.end()){
     
-    uint64_t st = missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME];
-    check(st + (3600*24*7) < timestamp, "Mission isn't ready yet, wait "+ to_string(st + (3600*24*7) - timestamp) +"s");
+        uint64_t st = missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME];
+        check(st + (3600*24*7) < timestamp, "Mission isn't ready yet, wait "+ to_string(st + (3600*24*7) - timestamp) +"s");
     }
-    auto size = std::distance(citiz.cbegin(),citiz.cend());
+    auto size = std::distance(apartments.cbegin(),apartments.cend());
     auto rnd = (timestamp % size) ;
-    auto start_mission_itr= citiz.begin();
+    auto start_mission_itr= apartments.begin();
     for (int i = 5; i < rnd; i++){
-        if(start_mission_itr == citiz.end()){break;}
-        if(size >5)start_mission_itr++;
+        if(start_mission_itr == apartments.end()){break;}
+        start_mission_itr++;
     }
 
     json apts;
     for (int i = 0; i < 5; i++){
 
-        if(start_mission_itr == citiz.end()){continue;}
+        if(start_mission_itr == apartments.end()){continue;}
         apts[start_mission_itr->account.to_string()][APARTMENT_SCORE]= 0;
         start_mission_itr++;
     }
     missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_APARTMENTS] = apts; 
-    missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME] = timestamp; 
-
+    missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME] = timestamp;
+    missions_data[APARTMENT_VOTING_MISSION][MISSION_COMPLETE] = "false"; 
+    
     string missions_data_str = missions_data.dump();
 
     missions.modify(missionsitr, get_self(), [&](auto &mod_acc) {

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -3567,7 +3567,6 @@ void clashdomewld::disablenot(name account ){
 
     require_auth(account);
     uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
-    missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME] = timestamp; 
 
     auto missionsitr = missions.find(account.value);
     json missions_data;
@@ -3580,6 +3579,8 @@ void clashdomewld::disablenot(name account ){
     missions_data = json::parse(missionsitr->missions);
     json voting_mission = missions_data[APARTMENT_VOTING_MISSION];
     voting_mission[MISSION_NOFITICATION_STATE] = "false";
+    voting_mission[APARTMENT_VOTING_START_TIME] = timestamp; 
+
     missions_data[APARTMENT_VOTING_MISSION] =voting_mission;
     string missions_data_str = missions_data.dump();
 

--- a/src/clashdomewld.cpp
+++ b/src/clashdomewld.cpp
@@ -3366,7 +3366,7 @@ void clashdomewld::initvotapt(name account){
     if(missionsitr == missions.end()){
         missionsitr = missions.emplace(CONTRACTN, [&](auto &new_a) {
             new_a.account = account;
-            new_a.missions = "";
+            new_a.missions = "{}";
         });   
     }else{
         missions_data = json::parse(missionsitr->missions);
@@ -3561,4 +3561,30 @@ void clashdomewld::voteconfig(asset voter_reward, asset voted_reward){
                     account_itr.voted_reward = voted_reward;
                 });
     }
+}
+
+void clashdomewld::disablenot(name account ){
+
+    require_auth(account);
+    uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
+    missions_data[APARTMENT_VOTING_MISSION][APARTMENT_VOTING_START_TIME] = timestamp; 
+
+    auto missionsitr = missions.find(account.value);
+    json missions_data;
+    if(missionsitr == missions.end()){
+        missionsitr = missions.emplace(CONTRACTN, [&](auto &new_a) {
+            new_a.account = account;
+            new_a.missions = "{}";
+        });   
+    }
+    missions_data = json::parse(missionsitr->missions);
+    json voting_mission = missions_data[APARTMENT_VOTING_MISSION];
+    voting_mission[MISSION_NOFITICATION_STATE] = "false";
+    missions_data[APARTMENT_VOTING_MISSION] =voting_mission;
+    string missions_data_str = missions_data.dump();
+
+    missions.modify(missionsitr, get_self(), [&](auto &mod_acc) {
+            mod_acc.missions = missions_data_str;
+        });
+
 }


### PR DESCRIPTION
En esta rama añado todo lo necesario para la mission de la votación de los apartamentos, se añaden 4 acciones,

Initvotapt : para iniciar la votación cada 7 días , comprueba que todo esté bien y escribe en la tabla missions toda la info cogiendo aleatoriamente 5 apartamentos de la tabla apartments.
https://github.com/ClashDome/clashdome-world-smart-contract/blob/d9f696d0ef935ac533589e812141adc0f105908c/src/clashdomewld.cpp#L3360-L3410

voteapts: aqui se envían los votos en un objeto y para cada voto se comprueba que sea correcto , que no se repita, y se modifican las huchas de los jugadores que han sido votados , al final se modifica también la hucha del que ha votado
https://github.com/ClashDome/clashdome-world-smart-contract/blob/d9f696d0ef935ac533589e812141adc0f105908c/src/clashdomewld.cpp#L3412-L3551

voteconfig: esta acción es de moderación para configurar las recompensas de la misión , se modifican las recompensas por estrella recibida (min 2 ) y la recompensa final del jugador que ha votado.
https://github.com/ClashDome/clashdome-world-smart-contract/blob/d9f696d0ef935ac533589e812141adc0f105908c/src/clashdomewld.cpp#L3552-L3571

diablenot: esta acción es para deshabilitar las notificaciones de la misión en caso de que el jugador cierre la ventana 
https://github.com/ClashDome/clashdome-world-smart-contract/blob/d9f696d0ef935ac533589e812141adc0f105908c/src/clashdomewld.cpp#L3573-L3598